### PR TITLE
fix datetime

### DIFF
--- a/app/src/interfaces/datetime/datetime.vue
+++ b/app/src/interfaces/datetime/datetime.vue
@@ -149,7 +149,7 @@ export default defineComponent({
 					return _value.value.getFullYear();
 				},
 				set(newYear: number | null) {
-					const newValue = _value.value ? new Date(_value.value) : new Date();
+					const newValue = _value.value ? new Date(_value.value) : new Date(0);
 					newValue.setFullYear(newYear || 0);
 					_value.value = newValue;
 				},
@@ -161,7 +161,7 @@ export default defineComponent({
 					return _value.value.getMonth();
 				},
 				set(newMonth: number | null) {
-					const newValue = _value.value ? new Date(_value.value) : new Date(0);
+					const newValue = _value.value ? new Date(_value.value) : new Date();
 					newValue.setMonth(newMonth || 0);
 					_value.value = newValue;
 				},
@@ -173,7 +173,7 @@ export default defineComponent({
 					return _value.value.getDate();
 				},
 				set(newDate: number | null) {
-					const newValue = _value.value ? new Date(_value.value) : new Date(0);
+					const newValue = _value.value ? new Date(_value.value) : new Date();
 					newValue.setDate(newDate || 1);
 					_value.value = newValue;
 				},
@@ -191,7 +191,7 @@ export default defineComponent({
 					return hours;
 				},
 				set(newHours: number | null) {
-					const newValue = _value.value ? new Date(_value.value) : new Date(0);
+					const newValue = _value.value ? new Date(_value.value) : new Date();
 					newValue.setHours(newHours || 0);
 					_value.value = newValue;
 				},
@@ -203,7 +203,7 @@ export default defineComponent({
 					return _value.value.getMinutes();
 				},
 				set(newMinutes: number | null) {
-					const newValue = _value.value ? new Date(_value.value) : new Date(0);
+					const newValue = _value.value ? new Date(_value.value) : new Date();
 					newValue.setMinutes(newMinutes || 0);
 					_value.value = newValue;
 				},
@@ -215,7 +215,7 @@ export default defineComponent({
 					return _value.value.getSeconds();
 				},
 				set(newSeconds: number | null) {
-					const newValue = _value.value ? new Date(_value.value) : new Date(0);
+					const newValue = _value.value ? new Date(_value.value) : new Date();
 					newValue.setSeconds(newSeconds || 0);
 					_value.value = newValue;
 				},


### PR DESCRIPTION
In my last PR I managed to do the opposite of what I planned. Now the Interface does what it should:
If one selects a Year, Month and Day are automatically set to 1. / January. Which means it will be possible to sort items by date when only the year is relevant.
I'm sorry that this took 2 PRs...